### PR TITLE
Custom Avro file base names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Switched to safe loading the YAML mapping, allowing only known ruby classes.
 - Added ability to yield in NdrAvro::Generator#process, enabling programmatic access to data as it is processed.
+- Added ability to specify an Avro file basename which is different to the processed file basename.
 
 ### Fixed
 

--- a/lib/ndr_avro/generator.rb
+++ b/lib/ndr_avro/generator.rb
@@ -12,10 +12,11 @@ module NdrAvro
     include NdrImport::UniversalImporterHelper
     include NdrAvro::Generator::AvroFileHelper
 
-    def initialize(filename, table_mappings, output_path = '')
+    def initialize(filename, table_mappings, options = {})
       @filename = filename
       load_mappings(table_mappings)
-      @output_path = Pathname.new(output_path)
+      @output_path = Pathname.new(options[:output_path] || '')
+      @basename = options[:basename] || File.basename(filename, File.extname(filename))
       @rawtext_column_names = {}
       @avro_column_types = {}
 

--- a/lib/ndr_avro/generator/avro_file_helper.rb
+++ b/lib/ndr_avro/generator/avro_file_helper.rb
@@ -13,15 +13,11 @@ module NdrAvro
       private
 
         def avro_filename(klass, mode)
-          basename = File.basename(@filename, File.extname(@filename))
-
-          @output_path.join("#{basename}.#{klass.underscore}.#{mode}.avro")
+          @output_path.join("#{@basename}.#{klass.underscore}.#{mode}.avro")
         end
 
         def avro_schema_filename(klass, mode)
-          basename = File.basename(@filename, File.extname(@filename))
-
-          @output_path.join("#{basename}.#{klass.underscore}.#{mode}.avsc")
+          @output_path.join("#{@basename}.#{klass.underscore}.#{mode}.avsc")
         end
 
         def avro_schema_type(type, options)

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -9,17 +9,9 @@ class GeneratorTest < Minitest::Test
   end
 
   def teardown
-    FileUtils.rm 'ABC_Collection-June-2020_03.hash.mapped.avro', force: true
-    FileUtils.rm 'ABC_Collection-June-2020_03.hash.mapped.avsc', force: true
-
-    FileUtils.rm 'ABC_Collection-June-2020_03.hash.raw.avro', force: true
-    FileUtils.rm 'ABC_Collection-June-2020_03.hash.raw.avsc', force: true
-
-    FileUtils.rm 'cross_worksheet_spreadsheet.hash.mapped.avro', force: true
-    FileUtils.rm 'cross_worksheet_spreadsheet.hash.mapped.avsc', force: true
-
-    FileUtils.rm 'cross_worksheet_spreadsheet.hash.raw.avro', force: true
-    FileUtils.rm 'cross_worksheet_spreadsheet.hash.raw.avsc', force: true
+    delete_avro_file_set('ABC_Collection-June-2020_03.hash')
+    delete_avro_file_set('cross_worksheet_spreadsheet.hash')
+    delete_avro_file_set('fake_dids_10.hash')
   end
 
   def test_the_output_schemas
@@ -207,6 +199,13 @@ class GeneratorTest < Minitest::Test
   end
 
   private
+
+    def delete_avro_file_set(basename)
+      FileUtils.rm "#{basename}.mapped.avro", force: true
+      FileUtils.rm "#{basename}.mapped.avsc", force: true
+      FileUtils.rm "#{basename}.raw.avro", force: true
+      FileUtils.rm "#{basename}.raw.avsc", force: true
+    end
 
     def read_avro(filename)
       # Open items.avro file in read mode


### PR DESCRIPTION
NdrAvro currently takes the base name of the processed file as the basename of the generated Avro files. This change allows you to define a custom basename. Useful where file are uploaded and the actual input filename differs from the `original_filename`.